### PR TITLE
attempt to fix global hook issue; allow accessly.config() to reset ac…

### DIFF
--- a/core.py
+++ b/core.py
@@ -17,6 +17,11 @@ def configure(**kwargs):
     if not _loaded_accessibilities:
         load_all_accessibility_features()  # auto-import modules
         _loaded_accessibilities = True
+        
+    # make sure we can run accessly.configure() to reset/disable accessibility features in ipynb notebooks
+    config.show_hooks.clear() # removes all previously registered draw/save hooks
+    config.settings.clear() # clears old flags
+    # reapplying only features in kwargs ensures: 1. features you want are applied but 2. features you omit are disabled.
 
     config.settings.update(kwargs)
 


### PR DESCRIPTION
fixed global hook issue #2 ; accessly.configure() now clears accessibility settings and allows default plotting without requiring kernel restart in jupyter notebooks. 