### PR TITLE
Alttext warns user when there's no metadata

### DIFF
--- a/accessly/accessibilities/alttext.py
+++ b/accessly/accessibilities/alttext.py
@@ -19,7 +19,17 @@ def apply(params):
     fontsize = params.get("fontsize", 14)
     fontname = params.get("fontname", "Arial")
 
-    def add_alttext():
+    def add_alttext(*args, **kwargs):
+        if 'metadata' not in kwargs:
+            print('============================================================================')
+            print('WARNING: Alt-text is selected, but no Description was added to the metadata!')
+            print('============================================================================')
+        else:
+            if 'Description' not in kwargs['metadata']:
+                print('============================================================================')
+                print('WARNING: Alt-text is selected, but no Description was added to the metadata!')
+                print('============================================================================')
+
         fig = plt.gcf()
         for ax in fig.axes:
 

--- a/accessly/accessibilities/colorblind.py
+++ b/accessly/accessibilities/colorblind.py
@@ -18,7 +18,7 @@ def apply(cb_options):
     colormap = _get_colormap(cb_types)
     print(f"[Colorblind] Using colormap: {colormap.name}")
 
-    def recolor_current_figure():
+    def recolor_current_figure(*args, **kwargs):
         fig = plt.gcf()
         for ax in fig.axes:
             # Lines

--- a/accessly/accessibilities/leftright.py
+++ b/accessly/accessibilities/leftright.py
@@ -16,7 +16,7 @@ def apply(params):
     color = params.get("color", "black")
     fontsize = params.get("fontsize", 14)
 
-    def add_lr_labels():
+    def add_lr_labels(*args, **kwargs):
         fig = plt.gcf()
         for ax in fig.axes:
 

--- a/accessly/accessibilities/legiblefont.py
+++ b/accessly/accessibilities/legiblefont.py
@@ -37,7 +37,7 @@ def apply(params):
             #(it wasn't)
             print("[LegibleFont] WARNING: Selected ",lf_font, " but this font is not available!")
 
-    def font_update_current_figure():
+    def font_update_current_figure(*args, **kwargs):
         fig = plt.gcf()
         #use rcParams to set font of ALL text
         plt.rcParams["font.weight"] = lf_weight

--- a/accessly/core.py
+++ b/accessly/core.py
@@ -41,16 +41,16 @@ def register_feature(name, handler_func):
     config.registered_features[name] = handler_func
 
 def _monkey_patch_matplotlib():
-    def run_show_hooks():
+    def run_show_hooks(*args, **kwargs):
         for hook in config.show_hooks:
             try:
-                hook()
+                hook(*args, **kwargs)
             except Exception as e:
                 print(f"[accessly] Warning: show hook failed: {e}")
 
     # Patch plt.show()
     def patched_show(*args, **kwargs):
-        run_show_hooks()
+        run_show_hooks(*args, **kwargs)
         _original_show(*args, **kwargs)
 
     plt.show = patched_show
@@ -59,7 +59,7 @@ def _monkey_patch_matplotlib():
     original_savefig = plt.savefig
 
     def patched_savefig(*args, **kwargs):
-        run_show_hooks()
+        run_show_hooks(*args, **kwargs)
         return original_savefig(*args, **kwargs)
 
     plt.savefig = patched_savefig


### PR DESCRIPTION
Added functionality for the alttext module to warn the user when alttext is selected but no description has been passed into the metadata argument of savefig. It also raises a warning when using the plt.show() function, even though metadata is not available at all.

To do this, *args and **kwargs are now passed into each of the modules, so each module has received an update.